### PR TITLE
Update: [CI] Bump GH Actions Versions to avoid warning/deprecation of them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,19 +18,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: "recursive"
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "17"
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
 
@@ -82,25 +82,25 @@ jobs:
           zip -r $debugSymbolName zygiskd/build/symbols/debug
 
       - name: Upload release
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.prepareArtifact.outputs.releaseName }}
           path: "./zksu-release/*"
 
       - name: Upload debug
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.prepareArtifact.outputs.debugName }}
           path: "./zksu-debug/*"
 
       - name: Upload release symbols
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.prepareArtifact.outputs.releaseName }}-symbols
           path: "zygiskd/build/symbols/release"
 
       - name: Upload debug symbols
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.prepareArtifact.outputs.debugName }}-symbols
           path: "zygiskd/build/symbols/debug"


### PR DESCRIPTION
## Changes

Updates GH(GitHub) Actions to its latest possible major Versions to avoid [warning or deprecation of them](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/), Updated ones Are:

`@actions/checkout`
`@actions/setup-java`
`@gradle/gradle-build-action -> @gradle/actions/setup-gradle` ([was delegated/replaced](https://github.com/gradle/actions/blob/c3acd19a4a9c9f84f3295b33fd2fc9d8c0d6cb1b/README.md#the-setup-gradle-action))

 `@actions/upload-artifact`

## Why 

The changes are required to be done as said by GitHub to avoid deprecation/not working CIs.

## Checkmarks

- [x] Changes made are expected to work as before.

## Additional information

Other GitHub actions that are not mentioned have updates included in latest patch/minor version of those.

**Update other relevant branches**