### PR TITLE
Make Magisk app detect zygisk is available

### DIFF
--- a/loader/src/ptracer/monitor.cpp
+++ b/loader/src/ptracer/monitor.cpp
@@ -228,6 +228,8 @@ struct SocketHandler : public EventHandler {
             tracing_state = TRACING;
           }
 
+          setenv("ZYGISK_ENABLED", "1", 1);
+
           updateStatus();
 
           break;
@@ -250,6 +252,8 @@ struct SocketHandler : public EventHandler {
 
           tracing_state = EXITING;
           strcpy(monitor_stop_reason, "user requested");
+
+          setenv("ZYGISK_ENABLED", "0", 1);
 
           updateStatus();
           loop.Stop();


### PR DESCRIPTION
## Changes

This PR sets ZYGISK_ENABLED environment variable to 1 when running.

## Why 

This allows users to easily recognize when (Re)Zygisk is running.

## Checkmarks

- [x] The modified functions have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Updated documentation (changelog).
