### PR TITLE
Clean up injection traces of ReZygisk that are detected by detectors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "loader/src/external/lsplt"]
 	path = loader/src/external/lsplt
-	url = https://github.com/LSPosed/lsplt
+	url = https://github.com/JingMatrix/LSPlt

--- a/loader/src/include/solist.hpp
+++ b/loader/src/include/solist.hpp
@@ -107,10 +107,11 @@ namespace SoList  {
     return addr == NULL ? NULL : *addr;
   }
 
-  static void DropSoPath(const char* target_path) {
+  static bool DropSoPath(const char* target_path) {
+    bool path_found = false;
     if (solist == NULL && !Initialize()) {
       LOGE("Failed to initialize solist");
-      return;
+      return path_found;
     }
     for (auto iter = solist; iter; iter = iter->get_next()) {
       if (iter->get_name() && iter->get_path() && strstr(iter->get_path(), target_path)) {
@@ -119,9 +120,11 @@ namespace SoList  {
         if (iter->get_size() > 0) {
             iter->set_size(0);
             SoInfo::soinfo_free(iter);
+            path_found = true;
         }
       }
     }
+    return path_found;
   }
 
   static bool Initialize() {

--- a/loader/src/injector/entry.cpp
+++ b/loader/src/injector/entry.cpp
@@ -23,6 +23,7 @@ void entry(void* addr, size_t size, const char* path) {
     logging::setfd(zygiskd::RequestLogcatFd());
 #endif
 
-    LOGI("Start hooking, call %p", hook_functions);
+    LOGI("start plt hooking");
     hook_functions();
+    clean_trace(path);
 }

--- a/loader/src/injector/entry.cpp
+++ b/loader/src/injector/entry.cpp
@@ -1,16 +1,17 @@
 #include "daemon.h"
 #include "logging.h"
 #include "zygisk.hpp"
-#include "module.hpp"
 
 using namespace std;
 
-void *self_handle = nullptr;
+void *start_addr = nullptr;
+size_t block_size = 0;
 
 extern "C" [[gnu::visibility("default")]]
-void entry(void* handle, const char* path) {
+void entry(void* addr, size_t size, const char* path) {
     LOGI("Zygisk library injected, version %s", ZKSU_VERSION);
-    self_handle = handle;
+    start_addr = addr;
+    block_size = size;
     zygiskd::Init(path);
 
     if (!zygiskd::PingHeartbeat()) {
@@ -22,6 +23,6 @@ void entry(void* handle, const char* path) {
     logging::setfd(zygiskd::RequestLogcatFd());
 #endif
 
-    LOGI("Start hooking");
+    LOGI("Start hooking, call %p", hook_functions);
     hook_functions();
 }

--- a/loader/src/injector/entry.cpp
+++ b/loader/src/injector/entry.cpp
@@ -25,5 +25,5 @@ void entry(void* addr, size_t size, const char* path) {
 
     LOGI("start plt hooking");
     hook_functions();
-    clean_trace(path);
+    clean_trace(path, 1, 0, false);
 }

--- a/loader/src/injector/hook.cpp
+++ b/loader/src/injector/hook.cpp
@@ -122,6 +122,7 @@ struct ZygiskContext {
 vector<tuple<dev_t, ino_t, const char *, void **>> *plt_hook_list;
 map<string, vector<JNINativeMethod>, StringCmp> *jni_hook_list;
 bool should_unmap_zygisk = false;
+std::vector<lsplt::MapInfo> cached_map_infos = {};
 
 } // namespace
 
@@ -187,6 +188,7 @@ DCL_HOOK_FUNC(int, pthread_attr_setstacksize, void *target, size_t size) {
 
     if (should_unmap_zygisk) {
         unhook_functions();
+        cached_map_infos.clear();
         if (should_unmap_zygisk) {
             // Because both `pthread_attr_setstacksize` and `dlclose` have the same function signature,
             // we can use `musttail` to let the compiler reuse our stack frame and thus
@@ -205,6 +207,8 @@ DCL_HOOK_FUNC(char *, strdup, const char *s) {
   if (strcmp(s, "com.android.internal.os.ZygoteInit") == 0) {
       LOGV("strdup %s", s);
       initialize_jni_hook();
+      cached_map_infos = lsplt::MapInfo::Scan();
+      LOGD("cached_map_infos updated");
     }
 
     return old_strdup(s);
@@ -268,7 +272,7 @@ void initialize_jni_hook() {
     auto get_created_java_vms = reinterpret_cast<jint (*)(JavaVM **, jsize, jsize *)>(
             dlsym(RTLD_DEFAULT, "JNI_GetCreatedJavaVMs"));
     if (!get_created_java_vms) {
-        for (auto &map: lsplt::MapInfo::Scan()) {
+        for (auto &map: cached_map_infos) {
             if (!map.path.ends_with("/libnativehelper.so")) continue;
             void *h = dlopen(map.path.data(), RTLD_LAZY);
             if (!h) {
@@ -349,7 +353,7 @@ bool ZygiskModule::RegisterModuleImpl(ApiTable *api, long *module) {
         api->v2.getFlags = [](auto) { return ZygiskModule::getFlags(); };
     }
     if (api_version >= 4) {
-        api->v4.pltHookCommit = lsplt::CommitHook;
+        api->v4.pltHookCommit = []() { return lsplt::CommitHook(cached_map_infos); };
         api->v4.pltHookRegister = [](dev_t dev, ino_t inode, const char *symbol, void *fn, void **backup) {
             if (dev == 0 || inode == 0 || symbol == nullptr || fn == nullptr)
                 return;
@@ -383,7 +387,7 @@ void ZygiskContext::plt_hook_exclude(const char *regex, const char *symbol) {
 void ZygiskContext::plt_hook_process_regex() {
     if (register_info.empty())
         return;
-    for (auto &map : lsplt::MapInfo::Scan()) {
+    for (auto &map : cached_map_infos) {
         if (map.offset != 0 || !map.is_private || !(map.perms & PROT_READ)) continue;
         for (auto &reg: register_info) {
             if (regexec(&reg.regex, map.path.data(), 0, nullptr, 0) != 0)
@@ -411,7 +415,7 @@ bool ZygiskContext::plt_hook_commit() {
         register_info.clear();
         ignore_info.clear();
     }
-    return lsplt::CommitHook();
+    return lsplt::CommitHook(cached_map_infos);
 }
 
 
@@ -719,8 +723,8 @@ ZygiskContext::~ZygiskContext() {
 
 } // namespace
 
-static bool hook_commit() {
-    if (lsplt::CommitHook()) {
+static bool hook_commit(std::vector<lsplt::MapInfo> &map_infos = cached_map_infos) {
+    if (lsplt::CommitHook(map_infos)) {
         return true;
     } else {
         LOGE("plt_hook failed");
@@ -752,23 +756,23 @@ void clean_trace(const char* path, bool spoof_maps) {
     LOGD("spoofing virtual maps for %s", path);
     // spoofing map names is futile in Android, we do it simply
     // to avoid Zygisk detections based on string comparison
-    for (auto &info : lsplt::MapInfo::Scan()) {
-        if (strstr(info.path.c_str(), path))
+    for (auto &map : lsplt::MapInfo::Scan()) {
+        if (strstr(map.path.c_str(), path))
         {
-            void *addr = (void *)info.start;
-            size_t size = info.end - info.start;
+            void *addr = (void *)map.start;
+            size_t size = map.end - map.start;
             void *copy = mmap(nullptr, size, PROT_WRITE, MAP_ANONYMOUS | MAP_SHARED, -1, 0);
             if (copy == MAP_FAILED) {
-                LOGE("failed to backup block %s [%p, %p]", info.path.c_str(), addr, (void*)info.end);
+                LOGE("failed to backup block %s [%p, %p]", map.path.c_str(), addr, (void*)map.end);
                 continue;
             }
 
-            if ((info.perms & PROT_READ) == 0) {
+            if ((map.perms & PROT_READ) == 0) {
                 mprotect(addr, size, PROT_READ);
             }
             memcpy(copy, addr, size);
             mremap(copy, size, size, MREMAP_MAYMOVE | MREMAP_FIXED, addr);
-            mprotect(addr, size, info.perms);
+            mprotect(addr, size, map.perms);
         }
     }
 }
@@ -783,7 +787,8 @@ void hook_functions() {
     // ino_t native_bridge_inode = 0;
     // dev_t native_bridge_dev = 0;
 
-    for (auto &map : lsplt::MapInfo::Scan()) {
+    cached_map_infos = lsplt::MapInfo::Scan();
+    for (auto &map : cached_map_infos) {
         if (map.path.ends_with("libandroid_runtime.so")) {
             android_runtime_inode = map.inode;
             android_runtime_dev = map.dev;
@@ -809,7 +814,7 @@ static void hook_unloader() {
     ino_t art_inode = 0;
     dev_t art_dev = 0;
 
-    for (auto &map : lsplt::MapInfo::Scan()) {
+    for (auto &map : cached_map_infos) {
         if (map.path.ends_with("/libart.so")) {
             art_inode = map.inode;
             art_dev = map.dev;
@@ -817,6 +822,12 @@ static void hook_unloader() {
         }
     }
 
+    if (art_dev == 0 || art_inode == 0) {
+        LOGE("virtual map for libart.so is not cached");
+        return;
+    } else {
+        LOGD("hook_unloader called with libart.so [%zu:%lu]", art_dev, art_inode);
+    }
     PLT_HOOK_REGISTER(art_dev, art_inode, pthread_attr_setstacksize);
     hook_commit();
 }

--- a/loader/src/injector/module.hpp
+++ b/loader/src/injector/module.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstring>
 #include <dlfcn.h>
 #include "api.hpp"
 
@@ -209,7 +210,7 @@ case 5:                                \
         int getModuleDir() const;
         void setOption(zygisk::Option opt);
         static uint32_t getFlags();
-        void tryUnload() const { if (unload) dlclose(handle); }
+        bool tryUnload() const { return unload && dlclose(handle) == 0; };
         void clearApi() { memset(&api, 0, sizeof(api)); }
         int getId() const { return id; }
 

--- a/loader/src/injector/zygisk.hpp
+++ b/loader/src/injector/zygisk.hpp
@@ -7,7 +7,7 @@ extern size_t block_size;
 
 void hook_functions();
 
-void clean_trace(const char* path);
+void clean_trace(const char* path, bool spoof_maps = false);
 
 void revert_unmount_ksu();
 

--- a/loader/src/injector/zygisk.hpp
+++ b/loader/src/injector/zygisk.hpp
@@ -7,6 +7,8 @@ extern size_t block_size;
 
 void hook_functions();
 
+void clean_trace(const char* path);
+
 void revert_unmount_ksu();
 
 void revert_unmount_magisk();

--- a/loader/src/injector/zygisk.hpp
+++ b/loader/src/injector/zygisk.hpp
@@ -7,7 +7,7 @@ extern size_t block_size;
 
 void hook_functions();
 
-void clean_trace(const char* path, bool spoof_maps = false);
+void clean_trace(const char* path, size_t load = 1, size_t unload = 0, bool spoof_maps = false);
 
 void revert_unmount_ksu();
 

--- a/loader/src/injector/zygisk.hpp
+++ b/loader/src/injector/zygisk.hpp
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <stdint.h>
 #include <jni.h>
-#include <vector>
 
-extern void *self_handle;
+extern void *start_addr;
+extern size_t block_size;
 
 void hook_functions();
 


### PR DESCRIPTION
## Changes

1. Replace `dlclose` of `libzygisk.so` by manually deleting its soinfo record and unmap its memory blocks.
2. Cache contents of `/proc/self/maps` for PLT hooks of `libart.so` to avoid reading this file in the target process.

Detailed explanations are given as commit messages.

## Why 

Injection detector applications, such as Native Test, Holmes, Native Detection and JingMatrix/Demo, have found traces of ReZygisk for a long time. Current pull-request will eliminate the traces brought by solist and virtual map scanning.

## Checkmarks

- [x] The modified functions have been tested.
- [x] Used the same indentation as the rest of the project.
- [ ] Updated documentation (changelog).

## Additional information

Please review this pull-request carefully to avoid my unnoticeable mistakes.
