### PR TITLE
fix: CHECK_DAEMON_EXIT 32 bit support

### DIFF
--- a/loader/src/ptracer/monitor.cpp
+++ b/loader/src/ptracer/monitor.cpp
@@ -438,7 +438,7 @@ static bool ensure_daemon_created(bool is_64bit) {
 }
 
 #define CHECK_DAEMON_EXIT(abi)                                                   \
-  if (status##abi.supported && pid == status##abi.daemon_pid) {                     \
+  if (status##abi.supported && pid == status##abi.daemon_pid) {                   \
     char status_str[64];                                                         \
     parse_status(status, status_str, sizeof(status_str));                        \
                                                                                  \

--- a/loader/src/ptracer/monitor.cpp
+++ b/loader/src/ptracer/monitor.cpp
@@ -438,7 +438,7 @@ static bool ensure_daemon_created(bool is_64bit) {
 }
 
 #define CHECK_DAEMON_EXIT(abi)                                                   \
-  if (status##abi.supported && pid == status##abi.daemon_pid) {                   \
+  if (status##abi.supported && pid == status##abi.daemon_pid) {                  \
     char status_str[64];                                                         \
     parse_status(status, status_str, sizeof(status_str));                        \
                                                                                  \

--- a/loader/src/ptracer/monitor.cpp
+++ b/loader/src/ptracer/monitor.cpp
@@ -438,7 +438,7 @@ static bool ensure_daemon_created(bool is_64bit) {
 }
 
 #define CHECK_DAEMON_EXIT(abi)                                                   \
-  if (status##abi.supported && pid == status64.daemon_pid) {                     \
+  if (status##abi.supported && pid == status##abi.daemon_pid) {                     \
     char status_str[64];                                                         \
     parse_status(status, status_str, sizeof(status_str));                        \
                                                                                  \


### PR DESCRIPTION
## Changes

CHECK_DAEMON_EXIT 32 bit support

## Why 

same as the title

## Checkmarks

- [ ] The modified functions have been tested.
- [x] Used the same indentation as the rest of the project.

## Additional information

If you have any additional information, write it here
