### PR TITLE
Update sepolicy.rule

### DIFF
--- a/module/src/sepolicy.rule
+++ b/module/src/sepolicy.rule
@@ -9,6 +9,7 @@ allow zygote su dir search
 allow zygote su {lnk_file file} read
 
 allow zygote adb_data_file dir search
+allow zygote adb_data_file file *
 allow zygote zygote process execmem
 allow system_server system_server process execmem
 allow zygote tmpfs file *


### PR DESCRIPTION
## Changes

Update sepolicy.rule

## Why 

Without this line, module such as magisk_proc_monitor will fail to load

## Checkmarks

- [x] The modified functions have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Updated documentation (changelog).

## Additional information

Example:
```
type=1400 audit(0.0:158): avc: denied { read } for path="/data/adb/modules/magisk_proc_monitor/zygisk/arm64-v8a.so" dev="dm-10" ino=283703 scontext=u:r:zygote:s0 tcontext=u:object_r:adb_data_file:s0 tclass=file permissive=0
```

