### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ As of now, we don't have integration with another platform for translations but 
 For any question related to ReZygisk or other PerformanC projects, feel free to join any of the following channels below:
 
 - Discord Channel: [PerformanC](https://discord.gg/uPveNfTuCJ)
-- ReZygisk Telegram Channel: [@rezygiskchat](https://t.me/rezygiskchat)
+- ReZygisk Telegram Channel: [@rezygisk](https://t.me/rezygisk)
 - PerformanC Telegram Channel: [@performancorg](https://t.me/performancorg)
 
 ## Contribution


### PR DESCRIPTION
ReZygisk chat link was used instead of the channel one.

## Changes

Write here about the changes you've made

## Why 

Write here why you think this should be merged

## Checkmarks

- [ ] The modified functions have been tested.
- [ ] Used the same indentation as the rest of the project.
- [ ] Updated documentation (changelog).

## Additional information

If you have any additional information, write it here
