### PR TITLE
Support Windows Build

### DIFF
--- a/zygiskd/build.gradle.kts
+++ b/zygiskd/build.gradle.kts
@@ -34,7 +34,7 @@ val CStandardFlags = arrayOf(
   "-DMIN_KSU_VERSION=$minKsuVersion",
   "-DMAX_KSU_VERSION=$maxKsuVersion",
   "-DMIN_MAGISK_VERSION=$minMagiskVersion",
-  "-DZKSU_VERSION=\"$verName\""
+  "-DZKSU_VERSION=\"\\\"$verName\\\"\""
 )
 
 val CFlagsRelease = arrayOf(
@@ -64,10 +64,24 @@ task("buildAndStrip") {
   doLast {
     val ndkPath = getLatestNDKPath()
 
-    val aarch64Compiler = Paths.get(ndkPath, "toolchains", "llvm", "prebuilt", "linux-x86_64", "bin", "aarch64-linux-android34-clang").toString()
-    val armv7aCompiler = Paths.get(ndkPath, "toolchains", "llvm", "prebuilt", "linux-x86_64", "bin", "armv7a-linux-androideabi34-clang").toString()
-    val x86Compiler = Paths.get(ndkPath, "toolchains", "llvm", "prebuilt", "linux-x86_64", "bin", "i686-linux-android34-clang").toString()
-    val x86_64Compiler = Paths.get(ndkPath, "toolchains", "llvm", "prebuilt", "linux-x86_64", "bin", "x86_64-linux-android34-clang").toString()
+    var hostTriple = ""
+    var suffix = ""
+
+    if (OperatingSystem.current().isWindows) {
+      hostTriple = "windows-x86_64"
+      suffix = ".cmd"
+    } else if (OperatingSystem.current().isLinux) {
+      hostTriple = "linux-x86_64"
+    } else if (OperatingSystem.current().isMacOsX) {
+      hostTriple = "darwin-x86_64"
+    } else {
+      throw UnsupportedOperationException ("System")
+    }
+
+    val aarch64Compiler = Paths.get(ndkPath, "toolchains", "llvm", "prebuilt", hostTriple, "bin", "aarch64-linux-android34-clang${suffix}").toString()
+    val armv7aCompiler = Paths.get(ndkPath, "toolchains", "llvm", "prebuilt", hostTriple, "bin", "armv7a-linux-androideabi34-clang${suffix}").toString()
+    val x86Compiler = Paths.get(ndkPath, "toolchains", "llvm", "prebuilt", hostTriple, "bin", "i686-linux-android34-clang${suffix}").toString()
+    val x86_64Compiler = Paths.get(ndkPath, "toolchains", "llvm", "prebuilt", hostTriple, "bin", "x86_64-linux-android34-clang${suffix}").toString()
 
     if (!Paths.get(aarch64Compiler).toFile().exists()) {
       throw Exception("aarch64 compiler not found at $aarch64Compiler")

--- a/zygiskd/build.gradle.kts
+++ b/zygiskd/build.gradle.kts
@@ -34,7 +34,7 @@ val CStandardFlags = arrayOf(
   "-DMIN_KSU_VERSION=$minKsuVersion",
   "-DMAX_KSU_VERSION=$maxKsuVersion",
   "-DMIN_MAGISK_VERSION=$minMagiskVersion",
-  "-DZKSU_VERSION=\"\\\"$verName\\\"\""
+  "-DZKSU_VERSION=\\\"$verName\\\""
 )
 
 val CFlagsRelease = arrayOf(


### PR DESCRIPTION
## Changes

This commit adds support for building the ReZygisk project on Windows platforms.

## Why 

Previously, building ReZygisk was primarily supported on Unix-like systems. By adding Windows build support, we enable developers who use Windows environments to compile and contribute to the project more easily. This change enhances cross-platform compatibility and broadens the contributor base.

## Checkmarks

- [ ] The modified functions have been tested.
- [ ] Used the same indentation as the rest of the project.
- [ ] Updated documentation (changelog).

## Additional information

If you have any additional information, write it here
