### PR TITLE
Place unloader PLT hook earlier to avoid crashing other threads

### DIFF
--- a/loader/src/injector/hook.cpp
+++ b/loader/src/injector/hook.cpp
@@ -277,7 +277,15 @@ DCL_HOOK_FUNC(char *, strdup, const char *s) {
  * threads crash if they try to use the PLT while we are in the process of hooking it.
  * For this task, hooking property_get was chosen as there are lots of calls to this, so it's
  * relatively unlikely to break.
- * https://github.com/aosp-mirror/platform_frameworks_base/blob/main/core/jni/AndroidRuntime.cpp
+ *
+ * The line where libart.so is loaded is:
+ * https://github.com/aosp-mirror/platform_frameworks_base/blob/1cdfff555f4a21f71ccc978290e2e212e2f8b168/core/jni/AndroidRuntime.cpp#L1266
+ *
+ * And shortly after that, in the startVm method that is called right after, there are many calls to property_get:
+ * https://github.com/aosp-mirror/platform_frameworks_base/blob/1cdfff555f4a21f71ccc978290e2e212e2f8b168/core/jni/AndroidRuntime.cpp#L791
+ *
+ * After we succeed in getting called at a point where libart.so is already loaded, we will ignore
+ * the rest of the property_get calls.
  */
 DCL_HOOK_FUNC(int, property_get, const char *key, char *value, const char *default_value) {
     hook_unloader();


### PR DESCRIPTION
## Changes

Apply the unloader PLT hook earlier.

## Why 

If other threads are trying to call functions through the PLT while PLT hooking is in progress, it can cause crashes like the one in #165. The developers of Perfetto have noticed this phenomenon: https://github.com/google/perfetto/issues/263#issuecomment-1063050197. Hopefully if the hooks are placed earlier, there won't be other threads running yet while they are being applied.

## Checkmarks

- [x] The modified functions have been tested.
- [x] Used the same indentation as the rest of the project.
- [ ] Updated documentation (changelog). => I can't find it, is there one?
