### PR TITLE
Umount if root starts with `/zygisk`

### DIFF
--- a/zygiskd/src/utils.c
+++ b/zygiskd/src/utils.c
@@ -628,6 +628,7 @@ bool umount_root(struct root_impl impl) {
     if (strcmp(mount.source, source_name) == 0) should_unmount = true;
     if (strncmp(mount.target, "/data/adb/modules", strlen("/data/adb/modules")) == 0) should_unmount = true;
     if (strncmp(mount.root, "/adb/modules/", strlen("/adb/modules/")) == 0) should_unmount = true;
+    if (strncmp(mount.root, "/zygisk", strlen("/zygisk")) == 0) should_unmount = true;
 
     if (!should_unmount) continue;
 


### PR DESCRIPTION
## Changes

Umount mounts where `mount.root` starts with `/zygisk`.

## Why 

LSposed makes this mount:
```
523 161 7:352 /zygisk_lsposed/bin/dex2oat32 /apex/com.android.art/bin/dex2oat32 ro,relatime shared:49 - ext4 /dev/block/loop44 rw,seclabel,i_version
524 161 7:352 /zygisk_lsposed/bin/dex2oat64 /apex/com.android.art/bin/dex2oat64 ro,relatime shared:49 - ext4 /dev/block/loop44 rw,seclabel,i_version
```
This mount is detected by many apps. We can safely umount it as only `installd` needs this.

## Checkmarks

- [x] The modified functions have been tested.
- [x] Used the same indentation as the rest of the project.
- [ ] Updated documentation (changelog). => I can't find it, is there one?

## Additional information

I'm not sure if this is in scope for ReZygisk, but with this small addition, all my apps run without needing an additional hiding module.
