### PR TITLE
Fix solist and maps spoofing

### DIFF
--- a/loader/src/injector/hook.cpp
+++ b/loader/src/injector/hook.cpp
@@ -711,10 +711,10 @@ void ZygiskContext::run_modules_post() {
 
         size_t i = 0;
         for (const auto &m : modules) {
-            module_addrs[i++] = m.getHandle();
+            module_addrs[i++] = m.getEntry();
         }
 
-        clean_trace("/data/adb", module_addrs, modules.size(), modules.size(), modules_unloaded, false);
+        clean_trace("/data/adb", module_addrs, modules.size(), modules.size(), modules_unloaded, true);
     }
 }
 
@@ -948,8 +948,8 @@ void clean_trace(const char *path, void **module_addrs, size_t module_addrs_leng
                 mprotect(addr, size, PROT_READ);
             }
             memcpy(copy, addr, size);
+            mprotect(copy, size, map.perms);
             mremap(copy, size, size, MREMAP_MAYMOVE | MREMAP_FIXED, addr);
-            mprotect(addr, size, map.perms);
         }
     }
 }

--- a/loader/src/injector/module.hpp
+++ b/loader/src/injector/module.hpp
@@ -213,7 +213,7 @@ case 5:                                \
         bool tryUnload() const { return unload && dlclose(handle) == 0; };
         void clearApi() { memset(&api, 0, sizeof(api)); }
         int getId() const { return id; }
-        void *getHandle() const { return handle; }
+        void *getEntry() const { return entry.ptr; }
 
         ZygiskModule(int id, void *handle, void *entry);
 


### PR DESCRIPTION
## Changes

- Fixed the address passed to `find_containing_library`
- Enabled `spoof_maps`
- Moved `mprotect` before `mremap` to avoid race condition

## Why 

It will make these features work again.

## Checkmarks

- [x] The modified functions have been tested.
- [x] Used the same indentation as the rest of the project.
- [ ] Updated documentation (changelog).

