### PR TITLE
Use seccomp to clear ptrace_message

### DIFF
--- a/loader/src/injector/clear.cpp
+++ b/loader/src/injector/clear.cpp
@@ -1,0 +1,94 @@
+#include <linux/seccomp.h>
+#include <linux/filter.h>
+#include <linux/audit.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <iostream>
+#include <fstream>
+#include <string>
+
+#include "logging.h"
+#include "zygisk.hpp"
+
+static bool seccomp_filters_visible() {
+    std::ifstream statusFile("/proc/self/status");
+    if (!statusFile.is_open()) {
+        return true;
+    }
+
+    std::string line;
+    while (std::getline(statusFile, line)) {
+        if (line.find("Seccomp_filters:") == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void send_seccomp_event() {
+    if (seccomp_filters_visible()) {
+        return;
+    }
+
+    __u32 args[4] = {0};
+
+    int rnd_fd = open("/dev/urandom", O_RDONLY);
+    if (rnd_fd == -1) {
+        PLOGE("send_seccomp_event: open(/dev/urandom)");
+        return;
+    }
+
+    if (read(rnd_fd, &args, sizeof(args)) != sizeof(args)) {
+        PLOGE("send_seccomp_event: read(rnd_fd)");
+        close(rnd_fd);
+        return;
+    }
+
+    close(rnd_fd);
+
+    args[0] |= 0x10000;
+
+    struct sock_filter filter[] = {
+            // Check syscall number
+            BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
+            BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_exit_group, 0, 9),
+
+            // Load and check arg0 (lower 32 bits)
+            BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
+            BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, args[0], 0, 7),
+
+            // Load and check arg1 (lower 32 bits)
+            BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[1])),
+            BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, args[1], 0, 5),
+
+            // Load and check arg2 (lower 32 bits)
+            BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[2])),
+            BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, args[2], 0, 3),
+
+            // Load and check arg3 (lower 32 bits)
+            BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[3])),
+            BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, args[3], 0, 1),
+
+            // All match: return TRACE => will trigger PTRACE_EVENT_SECCOMP
+            BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_TRACE),
+
+            // Default: allow
+            BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    };
+
+    struct sock_fprog prog = {
+            .len = (unsigned short)(sizeof(filter)/sizeof(filter[0])),
+            .filter = filter,
+    };
+
+    if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog)) {
+        PLOGE("prctl(SECCOMP)");
+        return;
+    }
+
+    /* INFO: This will trigger a ptrace event, syscall will not execute due to tracee_skip_syscall */
+    syscall(__NR_exit_group, args[0], args[1], args[2], args[3]);
+}

--- a/loader/src/injector/entry.cpp
+++ b/loader/src/injector/entry.cpp
@@ -25,4 +25,5 @@ void entry(void* addr, size_t size, const char* path) {
 
     void *module_addrs[1] = { addr };
     clean_trace(path, module_addrs, 1, 1, 0, false);
+    send_seccomp_event();
 }

--- a/loader/src/injector/zygisk.hpp
+++ b/loader/src/injector/zygisk.hpp
@@ -8,3 +8,5 @@ extern size_t block_size;
 void hook_functions();
 
 void clean_trace(const char *path, void **module_addrs, size_t module_addrs_length, size_t load, size_t unload, bool spoof_maps);
+
+void send_seccomp_event();

--- a/loader/src/ptracer/ptracer.c
+++ b/loader/src/ptracer/ptracer.c
@@ -403,7 +403,7 @@ bool trace_zygote(int pid) {
 
   int status;
 
-  if (ptrace(PTRACE_SEIZE, pid, 0, PTRACE_O_EXITKILL) == -1) {
+  if (ptrace(PTRACE_SEIZE, pid, 0, PTRACE_O_EXITKILL | PTRACE_O_TRACESECCOMP) == -1) {
     PLOGE("seize");
 
     return false;

--- a/loader/src/ptracer/utils.c
+++ b/loader/src/ptracer/utils.c
@@ -522,6 +522,32 @@ int fork_dont_care() {
   return pid;
 }
 
+void tracee_skip_syscall(int pid) {
+  struct user_regs_struct regs;
+  if (!get_regs(pid, &regs)) {
+    LOGE("failed to get seccomp regs");
+    exit(1);
+  }
+  regs.REG_SYSNR = -1;
+  if (!set_regs(pid, &regs)) {
+    LOGE("failed to set seccomp regs");
+    exit(1);
+  }
+
+  /* INFO: It might not work, don't check for error */
+#if defined(__aarch64__)
+  int sysnr = -1;
+  struct iovec iov = {
+    .iov_base = &sysnr,
+    .iov_len = sizeof (int),
+  };
+  ptrace(PTRACE_SETREGSET, pid, NT_ARM_SYSTEM_CALL, &iov);
+#elif defined(__arm__)
+  ptrace(PTRACE_SET_SYSCALL, pid, 0, (void*) -1);
+#endif
+
+}
+
 void wait_for_trace(int pid, int *status, int flags) {
   while (1) {
     pid_t result = waitpid(pid, status, flags);
@@ -532,7 +558,11 @@ void wait_for_trace(int pid, int *status, int flags) {
       exit(1);
     }
 
-    if (!WIFSTOPPED(*status)) {
+    if (*status >> 8 == (SIGTRAP | (PTRACE_EVENT_SECCOMP << 8))) {
+      tracee_skip_syscall(pid);
+      ptrace(PTRACE_CONT, pid, 0, 0);
+      continue;
+    } else if (!WIFSTOPPED(*status)) {
       char status_str[64];
       parse_status(*status, status_str, sizeof(status_str));
 

--- a/loader/src/ptracer/utils.h
+++ b/loader/src/ptracer/utils.h
@@ -37,18 +37,22 @@ void free_maps(struct maps *maps);
   #define REG_SP rsp
   #define REG_IP rip
   #define REG_RET rax
+  #define REG_SYSNR orig_rax
 #elif defined(__i386__)
   #define REG_SP esp
   #define REG_IP eip
   #define REG_RET eax
+  #define REG_SYSNR orig_eax
 #elif defined(__aarch64__)
   #define REG_SP sp
   #define REG_IP pc
   #define REG_RET regs[0]
+  #define REG_SYSNR regs[8]
 #elif defined(__arm__)
   #define REG_SP uregs[13]
   #define REG_IP uregs[15]
   #define REG_RET uregs[0]
+  #define REG_SYSNR uregs[7]
   #define user_regs_struct user_regs
 #endif
 


### PR DESCRIPTION
## Changes

First, we check if `Seccomp_filters:` is present. If it is, it can be used to detect the presence of a seccomp filter, so we only use the existing `PTRACE_SYSCALL` method.

Then we create a seccomp filter that will produce a `PTRACE_EVENT_SECCOMP` event with a `ptrace_message` of `0`. This is triggered by a syscall with number `__NR_exit_group` if the arguments match the four random 32-bit numbers we generated.

We trigger the event, setting `ptrace_message` to `0`, then the ptracer will make zygote skip the `exit_group` syscall.

## Why 

It will allow devices with lower kernel versions to pass `ptrace_message` detections. I tested it on a phone with kernel 4.14, where it successfully bypassed the detection, and also tested that it does not cause breakage (with or without commenting out the `seccomp_filters_visible` check) on kernels 5.15 or 6.1 either.

## Checkmarks

- [x] The modified functions have been tested.
- [x] Used the same indentation as the rest of the project.
- [ ] Updated documentation (changelog).

