### PR TITLE
Make module.prop more robust using cp instead of sed

### DIFF
--- a/module/src/customize.sh
+++ b/module/src/customize.sh
@@ -113,6 +113,8 @@ extract "$ZIPFILE" 'rezygisk.sh' "/data/adb/post-fs-data.d/"
 mkdir -p /data/adb/post-mount.d
 cp "/data/adb/post-fs-data.d/rezygisk.sh" "/data/adb/post-mount.d/rezygisk.sh"
 
+cp "$MODPATH/module.prop" "$MODPATH/module.prop.bak"
+
 chmod +x "$MODPATH/uninstall.sh"
 
 mv "$TMPDIR/sepolicy.rule" "$MODPATH"

--- a/module/src/rezygisk.sh
+++ b/module/src/rezygisk.sh
@@ -9,7 +9,7 @@ set -e
 
 MODDIR=/data/adb/modules/rezygisk
 
-# INFO: Removes the [...] in description part of module.prop
-sed -i -E 's/(description=)\[.*\] /\1/' $MODDIR/module.prop
+# INFO: Resets ReZygisk's module.prop to its default state which is saved upon installation.
+cp "$MODDIR/module.prop.bak" "$MODDIR/module.prop"
 
 exit 0


### PR DESCRIPTION
## Changes

Replaced sed approach of restoring RZ's module.prop with one using the cp command which is more reliable than sed which under some circumstances could corrupt the module.prop, with no way other than reflashing the module as a simple solution. Instead, it saves the default module.prop upon module installation as .bak and copies it to the original module.prop on each boot instead of sedding it.

## Why 

To make module.prop less prone to errors like corruption

## Checkmarks

- [x] The modified functions have been tested.
- [x] Used the same indentation as the rest of the project.
- [ ] Updated documentation (changelog).

## Additional information

If you have any additional information, write it here
