### PR TITLE
Improve action build time and add "all" rule to build debug & release at once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,12 @@ jobs:
           submodules: "recursive"
           fetch-depth: 0
 
-      - name: Accept NDK license
-        run: echo "y" | /usr/local/lib/android/sdk/cmdline-tools/latest/bin/sdkmanager "ndk;29.0.13113456"
+      - name: Setup NDK_PATH
+        run: echo "NDK_PATH=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
 
       - name: Build
         run: |
-          make release -j$(nproc)
-          make debug -j$(nproc)
+          make all -j$(nproc)
 
       - name: Upload release
         uses: actions/upload-artifact@v7

--- a/.github/workflows/trusted_ci.yml
+++ b/.github/workflows/trusted_ci.yml
@@ -14,9 +14,6 @@ jobs:
           submodules: "recursive"
           fetch-depth: 0
 
-      - name: Accept NDK license
-        run: echo "y" | /usr/local/lib/android/sdk/cmdline-tools/latest/bin/sdkmanager "ndk;29.0.13113456"
-
       - name: Setup keys
         env:
           private_key: ${{ secrets.ORG_PRIVATE_KEY }}
@@ -29,10 +26,12 @@ jobs:
             echo "$public_key" | base64 -d > module/public_key
           fi
 
+      - name: Setup NDK_PATH
+        run: echo "NDK_PATH=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
+
       - name: Build
         run: |
-          make release -j$(nproc)
-          make debug -j$(nproc)
+          make all -j$(nproc)
 
       - name: Upload release
         uses: actions/upload-artifact@v7

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ debug:
 release:
 	$(MAKE) BUILD_TYPE=release BUILD_DIR=$(BUILD_DIR) build
 
+all: debug release
+
 build: $(ZIP_FILE)
 
 $(LOADER_DONE): $(LOADER_INPUTS)


### PR DESCRIPTION
## Changes

Use default NDK present on the runner image instead of downloading it for faster CI runs and add the "all" rule to build debug and release at once, debug is still the default when not providing which rule to use.

## Why 

For faster CI run times and convenience for the "all" rule

## Checkmarks

- [x] The modified functions have been tested.
- [x] Used the same indentation as the rest of the project.
- [ ] Updated documentation (changelog).
