### PR TITLE
Use apd binary's original dir instead of its symlink

### DIFF
--- a/zygiskd/src/root_impl/apatch.c
+++ b/zygiskd/src/root_impl/apatch.c
@@ -12,7 +12,8 @@
 #include "apatch.h"
 
 void apatch_get_existence(struct root_impl_state *state) {
-  if (access("/data/adb/apd", F_OK) != 0) {
+  if (access("/data/adb/ap/bin/apd", F_OK) != 0) {
+
     state->state = Inexistent;
 
     return;


### PR DESCRIPTION
## Changes

Use /data/adb/ap/bin/apd for checking if apatch is present rather than the symlink /data/adb/apd

## Why 

Match KSU style

## Checkmarks

- [x] The modified functions have been tested.
- [x] Used the same indentation as the rest of the project.
- [ ] Updated documentation (changelog).
