### PR TITLE
Add late-load.sh for KernelSU LKM late-load mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ $(MODULE_DONE): $(LOADER_DONE) $(ZYGISKD_DONE) $(MODULE_INPUTS)
 		    -e 's/@MIN_MAGISK_VERSION@/$(MIN_MAGISK_VERSION)/g'             \
 		    module/src/$$script > $(MODULE_OUT)/$$script;                   \
 	done
+	@cp module/src/late-load.sh $(MODULE_OUT)/
 
 	@echo "Copying binaries..."
 	@for arch in $(ARCHS); do                                                                                  \

--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ After flashing, check the installation logs to ensure there are no errors, and i
 
 After rebooting, you can verify if ReZygisk is working properly by checking the module description in the `Modules` section of your root manager. The description should indicate that the necessary daemons are running. For example, if your environment supports both 64-bit and 32-bit, it should look similar to this: `[Monitor: ✅, ReZygisk 64-bit: ✅, ReZygisk 32-bit: ✅] Standalone implementation of Zygisk.`
 
+### KernelSU LKM late-load (jailbreak mode)
+
+On KernelSU setups where the kernel module is loaded after boot (`ksud late-load`, sometimes called jailbreak mode), `post-fs-data.sh` is **not** executed. ReZygisk ships a `late-load.sh` script for this path: it bootstraps the ptrace monitor via `post-fs-data.sh` when needed, then soft-reboots zygote so injection applies to new processes.
+
+This script runs automatically when you trigger late-load from the KernelSU manager. No manual setup is required after flashing ReZygisk.
+
+> [!NOTE]
+> The zygote restart causes a brief System UI reload (similar to a soft reboot). Apps already running before late-load must be restarted to receive Zygisk injection.
+
 ## Translation
 
 There are currently two different ways to contribute translations for ReZygisk:

--- a/module/src/customize.sh
+++ b/module/src/customize.sh
@@ -95,6 +95,7 @@ fi
 ui_print "- Extracting module files"
 extract "$ZIPFILE" 'module.prop'     "$MODPATH"
 extract "$ZIPFILE" 'post-fs-data.sh' "$MODPATH"
+extract "$ZIPFILE" 'late-load.sh'    "$MODPATH"
 extract "$ZIPFILE" 'service.sh'      "$MODPATH"
 extract "$ZIPFILE" 'uninstall.sh'    "$MODPATH"
 extract "$ZIPFILE" 'rezygisk.sh' "/data/adb/post-fs-data.d/"

--- a/module/src/late-load.sh
+++ b/module/src/late-load.sh
@@ -1,0 +1,28 @@
+#!/system/bin/sh
+
+MODDIR=${0%/*}
+
+if [ "$ZYGISK_ENABLED" ]; then
+  exit 0
+fi
+
+cd "$MODDIR"
+
+# INFO: KernelSU LKM late-load (ksud late-load) skips post-fs-data.sh.
+#         Bootstrap ReZygisk when the ptrace monitor is not running yet.
+monitor_running() {
+  pidof zygisk-ptrace64 >/dev/null 2>&1 && return 0
+  pidof zygisk-ptrace32 >/dev/null 2>&1 && return 0
+  return 1
+}
+
+if ! monitor_running; then
+  sh "$MODDIR/post-fs-data.sh"
+  sleep 1
+fi
+
+# INFO: Zygote started before root was available; restart it so ReZygisk
+#         injects into new app processes (soft reboot, not a full reboot).
+killall zygote64 zygote 2>/dev/null
+
+exit 0

--- a/scripts/sign.py
+++ b/scripts/sign.py
@@ -50,7 +50,7 @@ def sign_machikado(module_dir: str, sig_name: str, abi: str, is_64bit: bool, pri
   entries = []
 
   # INFO: The files where virtual = real
-  for fname in ["module.prop", "rezygisk.sh", "sepolicy.rule", "post-fs-data.sh", "service.sh", "uninstall.sh"]:
+  for fname in ["module.prop", "rezygisk.sh", "sepolicy.rule", "post-fs-data.sh", "late-load.sh", "service.sh", "uninstall.sh"]:
     vpath = root / fname
     entries.append((str(vpath), fname, str(vpath)))
 


### PR DESCRIPTION
```
Add late-load.sh for KernelSU LKM late-load (jailbreak mode)
```

## Changes

- Add `module/src/late-load.sh` for KernelSU `ksud late-load` / LKM jailbreak mode
- Extract and package `late-load.sh` in `customize.sh`, `Makefile`, and `scripts/sign.py`
- Document late-load behavior in README

## Why

KernelSU LKM setups load `kernelsu.ko` after the system has booted (`ksud late-load`). In this mode, **`post-fs-data.sh` is never run** — only `late-load.sh` (see [KernelSU module docs](https://kernelsu.org/guide/module.html#late-load-mode)).

ReZygisk currently has no `late-load.sh`, so users on jailbreak-style KernelSU installs get no Zygisk injection until they manually run `post-fs-data.sh` and restart zygote.

This PR ships the workflow users already rely on manually:

1. Bootstrap ReZygisk via `post-fs-data.sh` if the ptrace monitor is not running
2. Soft-reboot zygote (`killall zygote64 zygote`) so new processes receive injection

## Checkmarks

- [x] The modified functions have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Updated documentation (changelog).

## Additional information

- `late-load.sh` is only executed by KernelSU during late-load; normal boot still uses `post-fs-data.sh` unchanged.
- Uses `pidof` instead of `pgrep -f` for broader toybox/busybox compatibility.
- The zygote restart is intentional (soft reboot). Live `zygisk-ptrace64 trace` on an already-running zygote was found to be unreliable and can SIGKILL zygote on failure.
```
