### PR TITLE
add: GrapheneOS 17 Zygote function signatures

### DIFF
--- a/loader/src/injector/gen_jni_hooks.py
+++ b/loader/src/injector/gen_jni_hooks.py
@@ -243,6 +243,17 @@ spec_grapheneos_u = SpecApp('grapheneos_u', [uid, gid, gids, runtime_flags, rlim
     se_info, nice_name, is_child_zygote, instruction_set, app_data_dir, is_top_app, pkg_data_info_list,
     whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides, Anon(jlongArray)])
 
+# GrapheneOS Android 17 Support
+fas_grapheneos_c = ForkAndSpec('grapheneos_c', [Anon(jlongArray), uid, gid, gids, runtime_flags,
+    rlimits, mount_external, se_info, nice_name, fds_to_close, fds_to_ignore, is_child_zygote,
+    instruction_set, app_data_dir, is_top_app, Anon(jboolean), pkg_data_info_list,
+    whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides])
+
+spec_grapheneos_c = SpecApp('grapheneos_c', [Anon(jlongArray), uid, gid, gids, runtime_flags,
+    rlimits, mount_external, se_info, nice_name, is_child_zygote, instruction_set, app_data_dir,
+    is_top_app, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs,
+    mount_storage_dirs, mount_sysprop_overrides])
+
 hook_map = {}
 
 def gen_jni_def(clz, methods):
@@ -286,10 +297,10 @@ with open('jni_hooks.h', 'w') as f:
 
     zygote = 'com/android/internal/os/Zygote'
 
-    methods = [fas_l, fas_o, fas_p, fas_q_alt, fas_r, fas_u, fas_c, fas_samsung_m, fas_samsung_n, fas_samsung_o, fas_samsung_p, fas_samsung_b, fas_grapheneos_u]
+    methods = [fas_l, fas_o, fas_p, fas_q_alt, fas_r, fas_u, fas_c, fas_samsung_m, fas_samsung_n, fas_samsung_o, fas_samsung_p, fas_samsung_b, fas_grapheneos_u, fas_grapheneos_c]
     f.write(gen_jni_def(zygote, methods))
 
-    methods = [spec_q, spec_q_alt, spec_r, spec_u, spec_c, spec_samsung_q, spec_grapheneos_u]
+    methods = [spec_q, spec_q_alt, spec_r, spec_u, spec_c, spec_samsung_q, spec_grapheneos_u, spec_grapheneos_c]
     f.write(gen_jni_def(zygote, methods))
 
     methods = [server_l, server_samsung_q]

--- a/loader/src/injector/gen_jni_hooks.py
+++ b/loader/src/injector/gen_jni_hooks.py
@@ -205,6 +205,12 @@ fas_samsung_b = ForkAndSpec('samsung_b', [uid, gid, gids, runtime_flags, rlimits
     Anon(jboolean), is_top_app, pkg_data_info_list, whitelisted_data_info_list,
     mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides])
 
+# INFO: GrapheneOS Android 17
+fas_grapheneos_c = ForkAndSpec('grapheneos_c', [Anon(jlongArray), uid, gid, gids, runtime_flags,
+    rlimits, mount_external, se_info, nice_name, fds_to_close, fds_to_ignore, is_child_zygote,
+    instruction_set, app_data_dir, is_top_app, Anon(jboolean), pkg_data_info_list,
+    whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides])
+
 spec_q = SpecApp('q', [uid, gid, gids, runtime_flags, rlimits, mount_external, se_info,
     nice_name, is_child_zygote, instruction_set, app_data_dir])
 
@@ -228,6 +234,12 @@ spec_c = SpecApp('c', [uid, gid, Anon(jint), gids, runtime_flags, rlimits, mount
 spec_samsung_q = SpecApp('samsung_q', [uid, gid, gids, runtime_flags, rlimits, mount_external,
     se_info, Anon(jint), Anon(jint), nice_name, is_child_zygote, instruction_set, app_data_dir])
 
+# INFO: GrapheneOS Android 17
+spec_grapheneos_c = SpecApp('grapheneos_c', [Anon(jlongArray), uid, gid, gids, runtime_flags,
+    rlimits, mount_external, se_info, nice_name, is_child_zygote, instruction_set, app_data_dir,
+    is_top_app, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs,
+    mount_storage_dirs, mount_sysprop_overrides])
+
 server_l = ForkServer('l', [uid, gid, gids, runtime_flags, rlimits,
     permitted_capabilities, effective_capabilities])
 
@@ -242,17 +254,6 @@ fas_grapheneos_u = ForkAndSpec('grapheneos_u', [uid, gid, gids, runtime_flags, r
 spec_grapheneos_u = SpecApp('grapheneos_u', [uid, gid, gids, runtime_flags, rlimits, mount_external,
     se_info, nice_name, is_child_zygote, instruction_set, app_data_dir, is_top_app, pkg_data_info_list,
     whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides, Anon(jlongArray)])
-
-# GrapheneOS Android 17 Support
-fas_grapheneos_c = ForkAndSpec('grapheneos_c', [Anon(jlongArray), uid, gid, gids, runtime_flags,
-    rlimits, mount_external, se_info, nice_name, fds_to_close, fds_to_ignore, is_child_zygote,
-    instruction_set, app_data_dir, is_top_app, Anon(jboolean), pkg_data_info_list,
-    whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides])
-
-spec_grapheneos_c = SpecApp('grapheneos_c', [Anon(jlongArray), uid, gid, gids, runtime_flags,
-    rlimits, mount_external, se_info, nice_name, is_child_zygote, instruction_set, app_data_dir,
-    is_top_app, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs,
-    mount_storage_dirs, mount_sysprop_overrides])
 
 hook_map = {}
 

--- a/loader/src/injector/jni_hooks.h
+++ b/loader/src/injector/jni_hooks.h
@@ -209,6 +209,26 @@ __attribute__((no_stack_protector)) static jint nativeForkAndSpecialize_graphene
   rz_cleanup(&ctx);
   return ctx.pid;
 }
+__attribute__((no_stack_protector)) static jint nativeForkAndSpecialize_grapheneos_c(JNIEnv *env, jclass clazz, jlongArray _19, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jintArray fds_to_close, jintArray fds_to_ignore, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jboolean _20, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides) {
+  struct app_specialize_args_v5 args = { .uid = &uid, .gid = &gid, .gids = &gids, .runtime_flags = &runtime_flags, .rlimits = &rlimits, .mount_external = &mount_external, .se_info = &se_info, .nice_name = &nice_name, .instruction_set = &instruction_set, .app_data_dir = &app_data_dir };
+  args.fds_to_ignore = &fds_to_ignore;
+  args.is_child_zygote = &is_child_zygote;
+  args.is_top_app = &is_top_app;
+  args.pkg_data_info_list = &pkg_data_info_list;
+  args.whitelisted_data_info_list = &whitelisted_data_info_list;
+  args.mount_data_dirs = &mount_data_dirs;
+  args.mount_storage_dirs = &mount_storage_dirs;
+  args.mount_sysprop_overrides = &mount_sysprop_overrides;
+  struct zygisk_context ctx;
+  rz_init(&ctx, env, &args);
+  rz_nativeForkAndSpecialize_pre(&ctx);
+  ((nativeForkAndSpecialize_fn)nativeForkAndSpecialize_orig)(
+    env, clazz, _19, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, fds_to_close, fds_to_ignore, is_child_zygote, instruction_set, app_data_dir, is_top_app, _20, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides
+  );
+  rz_nativeForkAndSpecialize_post(&ctx);
+  rz_cleanup(&ctx);
+  return ctx.pid;
+}
 static JNINativeMethod nativeForkAndSpecialize_methods[] = {
   {
     "nativeForkAndSpecialize",
@@ -274,6 +294,11 @@ static JNINativeMethod nativeForkAndSpecialize_methods[] = {
     "nativeForkAndSpecialize",
     "(II[II[[IILjava/lang/String;Ljava/lang/String;[I[IZLjava/lang/String;Ljava/lang/String;Z[Ljava/lang/String;[Ljava/lang/String;ZZZ[J)I",
     (void *) &nativeForkAndSpecialize_grapheneos_u
+  },
+  {
+    "nativeForkAndSpecialize",
+    "([JII[II[[IILjava/lang/String;Ljava/lang/String;[I[IZLjava/lang/String;Ljava/lang/String;ZZ[Ljava/lang/String;[Ljava/lang/String;ZZZ)I",
+    (void *) &nativeForkAndSpecialize_grapheneos_c
   },
 };
 
@@ -387,6 +412,24 @@ __attribute__((no_stack_protector)) static void nativeSpecializeAppProcess_graph
   rz_nativeSpecializeAppProcess_post(&ctx);
   rz_cleanup(&ctx);
 }
+__attribute__((no_stack_protector)) static void nativeSpecializeAppProcess_grapheneos_c(JNIEnv *env, jclass clazz, jlongArray _21, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides) {
+  struct app_specialize_args_v5 args = { .uid = &uid, .gid = &gid, .gids = &gids, .runtime_flags = &runtime_flags, .rlimits = &rlimits, .mount_external = &mount_external, .se_info = &se_info, .nice_name = &nice_name, .instruction_set = &instruction_set, .app_data_dir = &app_data_dir };
+  args.is_child_zygote = &is_child_zygote;
+  args.is_top_app = &is_top_app;
+  args.pkg_data_info_list = &pkg_data_info_list;
+  args.whitelisted_data_info_list = &whitelisted_data_info_list;
+  args.mount_data_dirs = &mount_data_dirs;
+  args.mount_storage_dirs = &mount_storage_dirs;
+  args.mount_sysprop_overrides = &mount_sysprop_overrides;
+  struct zygisk_context ctx;
+  rz_init(&ctx, env, &args);
+  rz_nativeSpecializeAppProcess_pre(&ctx);
+  ((nativeSpecializeAppProcess_fn)nativeSpecializeAppProcess_orig)(
+    env, clazz, _21, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, is_child_zygote, instruction_set, app_data_dir, is_top_app, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides
+  );
+  rz_nativeSpecializeAppProcess_post(&ctx);
+  rz_cleanup(&ctx);
+}
 static JNINativeMethod nativeSpecializeAppProcess_methods[] = {
   {
     "nativeSpecializeAppProcess",
@@ -422,6 +465,11 @@ static JNINativeMethod nativeSpecializeAppProcess_methods[] = {
     "nativeSpecializeAppProcess",
     "(II[II[[IILjava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Z[Ljava/lang/String;[Ljava/lang/String;ZZZ[J)V",
     (void *) &nativeSpecializeAppProcess_grapheneos_u
+  },
+  {
+    "nativeSpecializeAppProcess",
+    "([JII[II[[IILjava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Z[Ljava/lang/String;[Ljava/lang/String;ZZZ)V",
+    (void *) &nativeSpecializeAppProcess_grapheneos_c
   },
 };
 

--- a/loader/src/injector/jni_hooks.h
+++ b/loader/src/injector/jni_hooks.h
@@ -189,7 +189,7 @@ __attribute__((no_stack_protector)) static jint nativeForkAndSpecialize_samsung_
   rz_cleanup(&ctx);
   return ctx.pid;
 }
-__attribute__((no_stack_protector)) static jint nativeForkAndSpecialize_grapheneos_u(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jintArray fds_to_close, jintArray fds_to_ignore, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides, jlongArray _17) {
+__attribute__((no_stack_protector)) static jint nativeForkAndSpecialize_grapheneos_u(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jintArray fds_to_close, jintArray fds_to_ignore, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides, jlongArray _20) {
   struct app_specialize_args_v5 args = { .uid = &uid, .gid = &gid, .gids = &gids, .runtime_flags = &runtime_flags, .rlimits = &rlimits, .mount_external = &mount_external, .se_info = &se_info, .nice_name = &nice_name, .instruction_set = &instruction_set, .app_data_dir = &app_data_dir };
   args.fds_to_ignore = &fds_to_ignore;
   args.is_child_zygote = &is_child_zygote;
@@ -203,13 +203,13 @@ __attribute__((no_stack_protector)) static jint nativeForkAndSpecialize_graphene
   rz_init(&ctx, env, &args);
   rz_nativeForkAndSpecialize_pre(&ctx);
   ((nativeForkAndSpecialize_fn)nativeForkAndSpecialize_orig)(
-    env, clazz, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, fds_to_close, fds_to_ignore, is_child_zygote, instruction_set, app_data_dir, is_top_app, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides, _17
+    env, clazz, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, fds_to_close, fds_to_ignore, is_child_zygote, instruction_set, app_data_dir, is_top_app, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides, _20
   );
   rz_nativeForkAndSpecialize_post(&ctx);
   rz_cleanup(&ctx);
   return ctx.pid;
 }
-__attribute__((no_stack_protector)) static jint nativeForkAndSpecialize_grapheneos_c(JNIEnv *env, jclass clazz, jlongArray _19, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jintArray fds_to_close, jintArray fds_to_ignore, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jboolean _20, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides) {
+__attribute__((no_stack_protector)) static jint nativeForkAndSpecialize_grapheneos_c(JNIEnv *env, jclass clazz, jlongArray _12, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jintArray fds_to_close, jintArray fds_to_ignore, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jboolean _13, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides) {
   struct app_specialize_args_v5 args = { .uid = &uid, .gid = &gid, .gids = &gids, .runtime_flags = &runtime_flags, .rlimits = &rlimits, .mount_external = &mount_external, .se_info = &se_info, .nice_name = &nice_name, .instruction_set = &instruction_set, .app_data_dir = &app_data_dir };
   args.fds_to_ignore = &fds_to_ignore;
   args.is_child_zygote = &is_child_zygote;
@@ -223,7 +223,7 @@ __attribute__((no_stack_protector)) static jint nativeForkAndSpecialize_graphene
   rz_init(&ctx, env, &args);
   rz_nativeForkAndSpecialize_pre(&ctx);
   ((nativeForkAndSpecialize_fn)nativeForkAndSpecialize_orig)(
-    env, clazz, _19, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, fds_to_close, fds_to_ignore, is_child_zygote, instruction_set, app_data_dir, is_top_app, _20, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides
+    env, clazz, _12, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, fds_to_close, fds_to_ignore, is_child_zygote, instruction_set, app_data_dir, is_top_app, _13, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides
   );
   rz_nativeForkAndSpecialize_post(&ctx);
   rz_cleanup(&ctx);
@@ -364,7 +364,7 @@ __attribute__((no_stack_protector)) static void nativeSpecializeAppProcess_u(JNI
   rz_nativeSpecializeAppProcess_post(&ctx);
   rz_cleanup(&ctx);
 }
-__attribute__((no_stack_protector)) static void nativeSpecializeAppProcess_c(JNIEnv *env, jclass clazz, jint uid, jint gid, jint _12, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides) {
+__attribute__((no_stack_protector)) static void nativeSpecializeAppProcess_c(JNIEnv *env, jclass clazz, jint uid, jint gid, jint _14, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides) {
   struct app_specialize_args_v5 args = { .uid = &uid, .gid = &gid, .gids = &gids, .runtime_flags = &runtime_flags, .rlimits = &rlimits, .mount_external = &mount_external, .se_info = &se_info, .nice_name = &nice_name, .instruction_set = &instruction_set, .app_data_dir = &app_data_dir };
   args.is_child_zygote = &is_child_zygote;
   args.is_top_app = &is_top_app;
@@ -377,42 +377,24 @@ __attribute__((no_stack_protector)) static void nativeSpecializeAppProcess_c(JNI
   rz_init(&ctx, env, &args);
   rz_nativeSpecializeAppProcess_pre(&ctx);
   ((nativeSpecializeAppProcess_fn)nativeSpecializeAppProcess_orig)(
-    env, clazz, uid, gid, _12, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, is_child_zygote, instruction_set, app_data_dir, is_top_app, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides
+    env, clazz, uid, gid, _14, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, is_child_zygote, instruction_set, app_data_dir, is_top_app, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides
   );
   rz_nativeSpecializeAppProcess_post(&ctx);
   rz_cleanup(&ctx);
 }
-__attribute__((no_stack_protector)) static void nativeSpecializeAppProcess_samsung_q(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jint _13, jint _14, jstring nice_name, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir) {
+__attribute__((no_stack_protector)) static void nativeSpecializeAppProcess_samsung_q(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jint _15, jint _16, jstring nice_name, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir) {
   struct app_specialize_args_v5 args = { .uid = &uid, .gid = &gid, .gids = &gids, .runtime_flags = &runtime_flags, .rlimits = &rlimits, .mount_external = &mount_external, .se_info = &se_info, .nice_name = &nice_name, .instruction_set = &instruction_set, .app_data_dir = &app_data_dir };
   args.is_child_zygote = &is_child_zygote;
   struct zygisk_context ctx;
   rz_init(&ctx, env, &args);
   rz_nativeSpecializeAppProcess_pre(&ctx);
   ((nativeSpecializeAppProcess_fn)nativeSpecializeAppProcess_orig)(
-    env, clazz, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, _13, _14, nice_name, is_child_zygote, instruction_set, app_data_dir
+    env, clazz, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, _15, _16, nice_name, is_child_zygote, instruction_set, app_data_dir
   );
   rz_nativeSpecializeAppProcess_post(&ctx);
   rz_cleanup(&ctx);
 }
-__attribute__((no_stack_protector)) static void nativeSpecializeAppProcess_grapheneos_u(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides, jlongArray _18) {
-  struct app_specialize_args_v5 args = { .uid = &uid, .gid = &gid, .gids = &gids, .runtime_flags = &runtime_flags, .rlimits = &rlimits, .mount_external = &mount_external, .se_info = &se_info, .nice_name = &nice_name, .instruction_set = &instruction_set, .app_data_dir = &app_data_dir };
-  args.is_child_zygote = &is_child_zygote;
-  args.is_top_app = &is_top_app;
-  args.pkg_data_info_list = &pkg_data_info_list;
-  args.whitelisted_data_info_list = &whitelisted_data_info_list;
-  args.mount_data_dirs = &mount_data_dirs;
-  args.mount_storage_dirs = &mount_storage_dirs;
-  args.mount_sysprop_overrides = &mount_sysprop_overrides;
-  struct zygisk_context ctx;
-  rz_init(&ctx, env, &args);
-  rz_nativeSpecializeAppProcess_pre(&ctx);
-  ((nativeSpecializeAppProcess_fn)nativeSpecializeAppProcess_orig)(
-    env, clazz, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, is_child_zygote, instruction_set, app_data_dir, is_top_app, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides, _18
-  );
-  rz_nativeSpecializeAppProcess_post(&ctx);
-  rz_cleanup(&ctx);
-}
-__attribute__((no_stack_protector)) static void nativeSpecializeAppProcess_grapheneos_c(JNIEnv *env, jclass clazz, jlongArray _21, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides) {
+__attribute__((no_stack_protector)) static void nativeSpecializeAppProcess_grapheneos_u(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides, jlongArray _21) {
   struct app_specialize_args_v5 args = { .uid = &uid, .gid = &gid, .gids = &gids, .runtime_flags = &runtime_flags, .rlimits = &rlimits, .mount_external = &mount_external, .se_info = &se_info, .nice_name = &nice_name, .instruction_set = &instruction_set, .app_data_dir = &app_data_dir };
   args.is_child_zygote = &is_child_zygote;
   args.is_top_app = &is_top_app;
@@ -425,7 +407,25 @@ __attribute__((no_stack_protector)) static void nativeSpecializeAppProcess_graph
   rz_init(&ctx, env, &args);
   rz_nativeSpecializeAppProcess_pre(&ctx);
   ((nativeSpecializeAppProcess_fn)nativeSpecializeAppProcess_orig)(
-    env, clazz, _21, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, is_child_zygote, instruction_set, app_data_dir, is_top_app, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides
+    env, clazz, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, is_child_zygote, instruction_set, app_data_dir, is_top_app, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides, _21
+  );
+  rz_nativeSpecializeAppProcess_post(&ctx);
+  rz_cleanup(&ctx);
+}
+__attribute__((no_stack_protector)) static void nativeSpecializeAppProcess_grapheneos_c(JNIEnv *env, jclass clazz, jlongArray _17, jint uid, jint gid, jintArray gids, jint runtime_flags, jobjectArray rlimits, jint mount_external, jstring se_info, jstring nice_name, jboolean is_child_zygote, jstring instruction_set, jstring app_data_dir, jboolean is_top_app, jobjectArray pkg_data_info_list, jobjectArray whitelisted_data_info_list, jboolean mount_data_dirs, jboolean mount_storage_dirs, jboolean mount_sysprop_overrides) {
+  struct app_specialize_args_v5 args = { .uid = &uid, .gid = &gid, .gids = &gids, .runtime_flags = &runtime_flags, .rlimits = &rlimits, .mount_external = &mount_external, .se_info = &se_info, .nice_name = &nice_name, .instruction_set = &instruction_set, .app_data_dir = &app_data_dir };
+  args.is_child_zygote = &is_child_zygote;
+  args.is_top_app = &is_top_app;
+  args.pkg_data_info_list = &pkg_data_info_list;
+  args.whitelisted_data_info_list = &whitelisted_data_info_list;
+  args.mount_data_dirs = &mount_data_dirs;
+  args.mount_storage_dirs = &mount_storage_dirs;
+  args.mount_sysprop_overrides = &mount_sysprop_overrides;
+  struct zygisk_context ctx;
+  rz_init(&ctx, env, &args);
+  rz_nativeSpecializeAppProcess_pre(&ctx);
+  ((nativeSpecializeAppProcess_fn)nativeSpecializeAppProcess_orig)(
+    env, clazz, _17, uid, gid, gids, runtime_flags, rlimits, mount_external, se_info, nice_name, is_child_zygote, instruction_set, app_data_dir, is_top_app, pkg_data_info_list, whitelisted_data_info_list, mount_data_dirs, mount_storage_dirs, mount_sysprop_overrides
   );
   rz_nativeSpecializeAppProcess_post(&ctx);
   rz_cleanup(&ctx);
@@ -487,13 +487,13 @@ __attribute__((no_stack_protector)) static jint nativeForkSystemServer_l(JNIEnv 
   rz_cleanup(&ctx);
   return ctx.pid;
 }
-__attribute__((no_stack_protector)) static jint nativeForkSystemServer_samsung_q(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jint _15, jint _16, jobjectArray rlimits, jlong permitted_capabilities, jlong effective_capabilities) {
+__attribute__((no_stack_protector)) static jint nativeForkSystemServer_samsung_q(JNIEnv *env, jclass clazz, jint uid, jint gid, jintArray gids, jint runtime_flags, jint _18, jint _19, jobjectArray rlimits, jlong permitted_capabilities, jlong effective_capabilities) {
   struct server_specialize_args_v1 args = { .uid = &uid, .gid = &gid, .gids = &gids, .runtime_flags = &runtime_flags, .permitted_capabilities = &permitted_capabilities, .effective_capabilities = &effective_capabilities };
   struct zygisk_context ctx;
   rz_init(&ctx, env, &args);
   rz_nativeForkSystemServer_pre(&ctx);
   ((nativeForkSystemServer_fn)nativeForkSystemServer_orig)(
-    env, clazz, uid, gid, gids, runtime_flags, _15, _16, rlimits, permitted_capabilities, effective_capabilities
+    env, clazz, uid, gid, gids, runtime_flags, _18, _19, rlimits, permitted_capabilities, effective_capabilities
   );
   rz_nativeForkSystemServer_post(&ctx);
   rz_cleanup(&ctx);


### PR DESCRIPTION
## Changes

Added `fas_grapheneos_c` and `spec_grapheneos_c` to JNI hook generator

## Why

Android 17 version of GrapheneOS moved `extraLongArgs` from the end to the front of the
argument list ([source permalink](https://github.com/GrapheneOS/platform_frameworks_base/blob/63af4a759452d08cacfdaa253254c8e519177cd9/core/java/com/android/internal/os/Zygote.java#L398-L471)). `fas_grapheneos_u` / `spec_grapheneos_u` put `Anon(jlongArray)` last, which matches GrapheneOS 16 but not 17. Without a new function signature, ReZygisk doesn't work. 

Note that they are also different from regular Android 17 signature (added in commit 946708e), as GrapheneOS function signatures often do.

## Checkmarks

- [x] The modified functions have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Updated documentation (changelog).

## Additional information

Tested on:

- Pixel 9 Pro (`caiman`), GrapheneOS build `2026072901`, Android 17 / SDK 37, `ro.zygote=zygote64`
- Magisk 30.7, with Magisk's built-in Zygisk disabled (`zygisk=0`) as ReZygisk requires
